### PR TITLE
Ap phase one

### DIFF
--- a/lib/components/app.js
+++ b/lib/components/app.js
@@ -9,6 +9,7 @@ import HomePage from './homepage';
 import WalletPage from './walletPage';
 import {pick, map} from 'lodash';
 import GamePage from './gamepage';
+import moment from 'moment';
 
 class App extends Component {
   constructor(){
@@ -16,6 +17,7 @@ class App extends Component {
     this.state = {
       user: null,
       userBudget: '',
+      date: '',
       onWalletPage: false,
       onGamePage: false,
       onHomePage: false
@@ -32,10 +34,10 @@ class App extends Component {
     this.setState({userBudget: budget});
   }
   componentDidMount() {
+    let date = moment().format('YYYY-MM-DD');
    firebase.auth().onAuthStateChanged(user => this.setState({ user }));
+   this.setState({date: date})
   }
-
-
   selectWalletPage(){
     this.setState({ onWalletPage:true, onGamePage:false, onHomePage:false})
   }
@@ -55,7 +57,7 @@ class App extends Component {
             selectHomePage = {this.selectHomePage.bind(this)}/>
           <SignOut
             signOut= {signOut} />
-          <GamePage user={this.state.user} userBudget= {this.state.userBudget}/>
+          <GamePage date={this.state.date} user={this.state.user} userBudget= {this.state.userBudget}/>
         </div>
       )
     }

--- a/lib/components/app.js
+++ b/lib/components/app.js
@@ -26,8 +26,6 @@ class App extends Component {
     reference.push({
       user:pick(user,'displayName', 'email','uid'),
       wallet :userBudget});
-    this.setState({userBudget:''})
-
   }
   setBudget(event){
     let budget = event.target.value;
@@ -35,7 +33,6 @@ class App extends Component {
   }
   componentDidMount() {
    firebase.auth().onAuthStateChanged(user => this.setState({ user }));
-   this.setState({})
   }
 
 
@@ -58,7 +55,7 @@ class App extends Component {
             selectHomePage = {this.selectHomePage.bind(this)}/>
           <SignOut
             signOut= {signOut} />
-          <GamePage />
+          <GamePage user={this.state.user} userBudget= {this.state.userBudget}/>
         </div>
       )
     }
@@ -84,7 +81,7 @@ class App extends Component {
        selectHomePage = {this.selectHomePage.bind(this)}/>
       <SignOut signOut= {signOut} />
       <HomePage user= {this.state.user} />
-        <Budget setBudget={this.setBudget.bind(this)}
+      <Budget setBudget={this.setBudget.bind(this)}
         userBudget={this.state.userBudget}
         saveBudget={this.saveBudget.bind(this)}/>
       </div>

--- a/lib/components/gamepage.js
+++ b/lib/components/gamepage.js
@@ -1,22 +1,48 @@
 import React, { Component } from 'react';
-
-
+import firebase, { reference } from '../firebase';
+import {pick, map} from 'lodash';
 
 class GamePage extends Component {
+  constructor(){
+    super();
+    this.state = {
+      wager: ''
+    };
+  }
+  saveBet(user, userBudget, wager){
+    reference.push({
+      user:pick(user,'displayName', 'email','uid'),
+      wallet :userBudget,
+      wager: wager
+    });
+  }
+  setWager(location){
+    let userInput = parseInt(location.target.value);
+    this.setState({wager: userInput});
+  }
   render(){
+    let userBudget = this.props.userBudget;
+    let user = this.props.user;
+    let wager = this.state.wager;
     return (
       <div>
         <h2>Today's Schedule</h2>
         <article>
         <h3>SPORT TEAM At SPORT TEAM</h3>
-        <button>Bet!</button>
+        <input id="wager"
+        value={this.state.wager}
+        placeholder="Enter your wager!"
+        onChange={(event) => this.setWager(event)}
+        type="number" />
+        <button
+          onClick={this.saveBet(user, userBudget, wager)}>Bet!</button>
         </article>
 
         <article>
         <h3>SPORT TEAM At SPORT TEAM</h3>
         <button>Bet!</button>
         </article>
-        
+
         <article>
         <h3>SPORT TEAM At SPORT TEAM</h3>
         <button>Bet!</button>

--- a/lib/components/gamepage.js
+++ b/lib/components/gamepage.js
@@ -1,13 +1,25 @@
 import React, { Component } from 'react';
 import firebase, { reference } from '../firebase';
-import {pick, map} from 'lodash';
+import {pick, filter, map} from 'lodash';
+import stats from '../../stats';
 
 class GamePage extends Component {
   constructor(){
     super();
     this.state = {
-      wager: ''
+      wager: '',
+      todaysGames: []
     };
+  }
+  componentDidMount(){
+    this.getTodayGames();
+  }
+  getTodayGames(){
+    let games = JSON.parse(stats)['fullgameschedule']['gameentry'];
+    let todaysGames = filter(games, (game) => {
+      return game.date === this.props.date
+    });
+    this.setState({todaysGames: todaysGames});
   }
   saveBet(user, userBudget, wager){
     reference.push({
@@ -24,29 +36,20 @@ class GamePage extends Component {
     let userBudget = this.props.userBudget;
     let user = this.props.user;
     let wager = this.state.wager;
+    let gamesList = (<ul className='games-list'>{this.state.todaysGames.map(g => <div><li className='game'>{g.date}</li><li>{g.awayTeam.City} FACING OFF AGAINST {g.homeTeam.City}</li><li>{g.time} @ {g.location}</li></div>)}</ul>);
+
     return (
       <div>
         <h2>Today's Schedule</h2>
-        <article>
-        <h3>SPORT TEAM At SPORT TEAM</h3>
+        {gamesList}
         <input id="wager"
         value={this.state.wager}
         placeholder="Enter your wager!"
         onChange={(event) => this.setWager(event)}
         type="number" />
         <button
-          onClick={this.saveBet(user, userBudget, wager)}>Bet!</button>
-        </article>
-
-        <article>
-        <h3>SPORT TEAM At SPORT TEAM</h3>
-        <button>Bet!</button>
-        </article>
-
-        <article>
-        <h3>SPORT TEAM At SPORT TEAM</h3>
-        <button>Bet!</button>
-        </article>
+          onClick={this.saveBet(user, userBudget, wager)}>Bet!
+        </button>
       </div>
     );
   }

--- a/lib/components/gamepage.js
+++ b/lib/components/gamepage.js
@@ -36,20 +36,19 @@ class GamePage extends Component {
     let userBudget = this.props.userBudget;
     let user = this.props.user;
     let wager = this.state.wager;
-    let gamesList = (<ul className='games-list'>{this.state.todaysGames.map(g => <div><li className='game'>{g.date}</li><li>{g.awayTeam.City} FACING OFF AGAINST {g.homeTeam.City}</li><li>{g.time} @ {g.location}</li></div>)}</ul>);
+    let gamesList = (<ul className='games-list'>{this.state.todaysGames.map(g => <div><li className='game'>{g.date}</li><li>{g.awayTeam.City} FACING OFF AGAINST {g.homeTeam.City}</li><li>{g.time} @ {g.location}</li><input id="wager"
+    value={this.state.wager}
+    placeholder="Enter your wager!"
+    onChange={(event) => this.setWager(event)}
+    type="number" />
+    <button
+      onClick={this.saveBet(user, userBudget, wager)}>Bet!
+    </button></div>)}</ul>);
 
     return (
       <div>
         <h2>Today's Schedule</h2>
         {gamesList}
-        <input id="wager"
-        value={this.state.wager}
-        placeholder="Enter your wager!"
-        onChange={(event) => this.setWager(event)}
-        type="number" />
-        <button
-          onClick={this.saveBet(user, userBudget, wager)}>Bet!
-        </button>
       </div>
     );
   }

--- a/stats.json
+++ b/stats.json
@@ -1,0 +1,20920 @@
+const stats = JSON.stringify({
+fullgameschedule: {
+lastUpdatedOn: null,
+gameentry: [
+{
+date: "2016-10-27",
+time: "8:00PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2016-10-27",
+time: "8:00PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2016-10-27",
+time: "10:30PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2016-10-28",
+time: "7:00PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2016-10-28",
+time: "7:30PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2016-10-28",
+time: "7:30PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2016-10-28",
+time: "7:30PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2016-10-28",
+time: "7:30PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2016-10-28",
+time: "7:30PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2016-10-28",
+time: "8:00PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2016-10-28",
+time: "8:00PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2016-10-28",
+time: "8:00PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2016-10-28",
+time: "8:00PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2016-10-28",
+time: "10:00PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2016-10-28",
+time: "10:00PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2016-10-28",
+time: "10:00PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2016-10-28",
+time: "10:30PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2016-10-29",
+time: "7:00PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2016-10-29",
+time: "8:00PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2016-10-29",
+time: "10:30PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2016-10-30",
+time: "7:00PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2016-10-30",
+time: "7:00PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2016-10-30",
+time: "7:00PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2016-10-30",
+time: "7:30PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2016-10-30",
+time: "7:30PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2016-10-30",
+time: "8:00PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2016-10-30",
+time: "8:00PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2016-10-30",
+time: "8:30PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2016-10-30",
+time: "9:00PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2016-10-30",
+time: "9:30PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2016-10-30",
+time: "10:00PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2016-10-30",
+time: "10:30PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2016-10-31",
+time: "7:00PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2016-10-31",
+time: "7:00PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2016-10-31",
+time: "7:30PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2016-10-31",
+time: "8:00PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2016-10-31",
+time: "10:00PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2016-10-31",
+time: "10:30PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2016-11-01",
+time: "2:00PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2016-11-01",
+time: "3:30PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2016-11-01",
+time: "6:00PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2016-11-01",
+time: "6:00PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2016-11-01",
+time: "7:00PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2016-11-01",
+time: "7:00PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2016-11-01",
+time: "9:30PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2016-11-02",
+time: "7:00PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2016-11-02",
+time: "7:30PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2016-11-02",
+time: "7:30PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2016-11-02",
+time: "8:00PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2016-11-02",
+time: "8:00PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2016-11-02",
+time: "10:30PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2016-11-02",
+time: "10:30PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2016-11-03",
+time: "7:00PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2016-11-03",
+time: "7:30PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2016-11-03",
+time: "7:30PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2016-11-03",
+time: "8:00PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2016-11-03",
+time: "8:30PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2016-11-03",
+time: "10:00PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2016-11-03",
+time: "10:30PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2016-11-04",
+time: "7:00PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2016-11-04",
+time: "7:00PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2016-11-04",
+time: "8:00PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2016-11-04",
+time: "8:00PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2016-11-04",
+time: "8:00PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2016-11-04",
+time: "8:00PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2016-11-04",
+time: "8:00PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2016-11-04",
+time: "9:00PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2016-11-04",
+time: "9:00PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2016-11-04",
+time: "10:30PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2016-11-05",
+time: "8:00PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2016-11-05",
+time: "8:00PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2016-11-05",
+time: "8:30PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2016-11-05",
+time: "9:00PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2016-11-05",
+time: "10:30PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2016-11-06",
+time: "7:00PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2016-11-06",
+time: "7:30PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2016-11-06",
+time: "7:30PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2016-11-06",
+time: "7:30PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2016-11-06",
+time: "7:30PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2016-11-06",
+time: "8:00PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2016-11-06",
+time: "8:00PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2016-11-06",
+time: "9:30PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2016-11-06",
+time: "10:30PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2016-11-06",
+time: "10:30PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2016-11-07",
+time: "6:00PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2016-11-07",
+time: "7:00PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2016-11-07",
+time: "7:30PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2016-11-07",
+time: "8:30PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2016-11-07",
+time: "8:30PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2016-11-07",
+time: "8:30PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2016-11-07",
+time: "9:00PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2016-11-07",
+time: "10:00PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2016-11-07",
+time: "10:30PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2016-11-08",
+time: "3:30PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2016-11-08",
+time: "3:30PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2016-11-08",
+time: "6:00PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2016-11-08",
+time: "7:00PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2016-11-08",
+time: "9:00PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2016-11-09",
+time: "7:00PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2016-11-09",
+time: "7:00PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2016-11-09",
+time: "8:00PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2016-11-09",
+time: "9:00PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2016-11-09",
+time: "10:00PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2016-11-09",
+time: "10:30PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2016-11-09",
+time: "10:30PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2016-11-10",
+time: "7:00PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2016-11-10",
+time: "7:00PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2016-11-10",
+time: "7:30PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2016-11-10",
+time: "7:30PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2016-11-10",
+time: "8:00PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2016-11-10",
+time: "8:00PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2016-11-10",
+time: "8:00PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2016-11-11",
+time: "7:00PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2016-11-11",
+time: "7:00PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2016-11-11",
+time: "7:00PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2016-11-11",
+time: "7:30PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2016-11-11",
+time: "8:00PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2016-11-11",
+time: "8:00PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2016-11-11",
+time: "8:00PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2016-11-11",
+time: "8:00PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2016-11-11",
+time: "9:00PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2016-11-11",
+time: "10:00PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2016-11-11",
+time: "10:30PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2016-11-12",
+time: "7:30PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2016-11-12",
+time: "8:00PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2016-11-12",
+time: "10:30PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2016-11-13",
+time: "7:00PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2016-11-13",
+time: "7:00PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2016-11-13",
+time: "7:30PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2016-11-13",
+time: "7:30PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2016-11-13",
+time: "7:30PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2016-11-13",
+time: "8:00PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2016-11-13",
+time: "8:00PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2016-11-13",
+time: "8:00PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2016-11-13",
+time: "8:30PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2016-11-13",
+time: "9:00PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2016-11-13",
+time: "10:00PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2016-11-14",
+time: "3:30PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2016-11-14",
+time: "7:00PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2016-11-14",
+time: "8:00PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2016-11-14",
+time: "8:30PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2016-11-14",
+time: "8:30PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2016-11-14",
+time: "9:00PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2016-11-14",
+time: "10:30PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2016-11-15",
+time: "2:00PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2016-11-15",
+time: "3:30PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2016-11-15",
+time: "5:00PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2016-11-15",
+time: "6:00PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2016-11-15",
+time: "7:00PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2016-11-15",
+time: "9:00PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2016-11-15",
+time: "9:30PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2016-11-16",
+time: "7:00PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2016-11-16",
+time: "8:00PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2016-11-16",
+time: "8:00PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2016-11-16",
+time: "8:00PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2016-11-16",
+time: "8:30PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2016-11-16",
+time: "9:00PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2016-11-17",
+time: "7:00PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2016-11-17",
+time: "7:30PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2016-11-17",
+time: "7:30PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2016-11-17",
+time: "7:30PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2016-11-17",
+time: "7:30PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2016-11-17",
+time: "8:00PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2016-11-17",
+time: "10:30PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2016-11-18",
+time: "7:00PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2016-11-18",
+time: "7:00PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2016-11-18",
+time: "7:00PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2016-11-18",
+time: "7:30PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2016-11-18",
+time: "8:00PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2016-11-18",
+time: "8:00PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2016-11-18",
+time: "8:00PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2016-11-18",
+time: "8:30PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2016-11-18",
+time: "9:00PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2016-11-18",
+time: "10:30PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2016-11-19",
+time: "7:30PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2016-11-19",
+time: "8:00PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2016-11-19",
+time: "10:30PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2016-11-20",
+time: "7:00PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2016-11-20",
+time: "7:30PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2016-11-20",
+time: "8:00PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2016-11-20",
+time: "8:00PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2016-11-20",
+time: "8:00PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2016-11-20",
+time: "8:00PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2016-11-20",
+time: "8:30PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2016-11-20",
+time: "9:00PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2016-11-20",
+time: "10:00PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2016-11-20",
+time: "10:30PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2016-11-20",
+time: "10:30PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2016-11-21",
+time: "5:00PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2016-11-21",
+time: "7:00PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2016-11-21",
+time: "7:30PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2016-11-21",
+time: "7:30PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2016-11-21",
+time: "8:00PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2016-11-21",
+time: "8:00PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2016-11-21",
+time: "8:30PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2016-11-22",
+time: "3:30PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2016-11-22",
+time: "6:00PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2016-11-22",
+time: "6:00PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2016-11-22",
+time: "7:00PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2016-11-22",
+time: "8:00PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2016-11-22",
+time: "9:30PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2016-11-23",
+time: "7:00PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2016-11-23",
+time: "7:00PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2016-11-23",
+time: "7:30PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2016-11-23",
+time: "8:00PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2016-11-23",
+time: "8:00PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2016-11-23",
+time: "8:30PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2016-11-23",
+time: "9:00PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2016-11-24",
+time: "7:00PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2016-11-24",
+time: "8:00PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2016-11-24",
+time: "8:00PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2016-11-24",
+time: "9:00PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2016-11-24",
+time: "10:00PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2016-11-24",
+time: "10:30PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2016-11-25",
+time: "7:00PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2016-11-25",
+time: "7:00PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2016-11-25",
+time: "7:30PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2016-11-25",
+time: "7:30PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2016-11-25",
+time: "7:30PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2016-11-25",
+time: "8:00PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2016-11-25",
+time: "8:00PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2016-11-25",
+time: "8:00PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2016-11-25",
+time: "8:00PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2016-11-25",
+time: "8:30PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2016-11-25",
+time: "9:00PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2016-11-25",
+time: "10:30PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2016-11-27",
+time: "7:00PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2016-11-27",
+time: "7:00PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2016-11-27",
+time: "7:30PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2016-11-27",
+time: "7:30PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2016-11-27",
+time: "8:00PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2016-11-27",
+time: "8:00PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2016-11-27",
+time: "8:00PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2016-11-27",
+time: "8:00PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2016-11-27",
+time: "9:00PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2016-11-27",
+time: "9:30PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2016-11-27",
+time: "10:00PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2016-11-27",
+time: "10:30PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2016-11-28",
+time: "7:00PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2016-11-28",
+time: "7:30PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2016-11-28",
+time: "8:30PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2016-11-28",
+time: "8:30PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2016-11-28",
+time: "9:00PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2016-11-28",
+time: "10:00PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2016-11-28",
+time: "10:30PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2016-11-29",
+time: "2:00PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2016-11-29",
+time: "3:30PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2016-11-29",
+time: "6:00PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2016-11-29",
+time: "6:00PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2016-11-29",
+time: "6:00PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2016-11-29",
+time: "6:00PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2016-11-29",
+time: "7:30PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2016-11-29",
+time: "9:30PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2016-11-30",
+time: "7:30PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2016-11-30",
+time: "7:30PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2016-11-30",
+time: "8:00PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2016-11-30",
+time: "8:00PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2016-11-30",
+time: "8:00PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2016-11-30",
+time: "9:00PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2016-11-30",
+time: "10:00PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2016-11-30",
+time: "10:30PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2016-12-01",
+time: "7:00PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2016-12-01",
+time: "7:00PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2016-12-01",
+time: "7:30PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2016-12-01",
+time: "8:00PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2016-12-01",
+time: "8:00PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2016-12-01",
+time: "10:00PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2016-12-02",
+time: "7:00PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2016-12-02",
+time: "7:00PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2016-12-02",
+time: "7:30PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2016-12-02",
+time: "7:30PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2016-12-02",
+time: "8:00PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2016-12-02",
+time: "8:00PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2016-12-02",
+time: "8:00PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2016-12-02",
+time: "8:30PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2016-12-02",
+time: "10:30PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2016-12-03",
+time: "7:00PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2016-12-03",
+time: "7:30PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2016-12-03",
+time: "9:00PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2016-12-03",
+time: "9:30PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2016-12-03",
+time: "10:00PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2016-12-03",
+time: "10:00PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2016-12-04",
+time: "7:00PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2016-12-04",
+time: "7:00PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2016-12-04",
+time: "7:30PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2016-12-04",
+time: "8:00PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2016-12-04",
+time: "8:30PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2016-12-04",
+time: "9:30PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2016-12-05",
+time: "1:00PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2016-12-05",
+time: "5:00PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2016-12-05",
+time: "8:00PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2016-12-05",
+time: "8:00PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2016-12-05",
+time: "8:00PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2016-12-05",
+time: "8:00PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2016-12-05",
+time: "8:30PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2016-12-05",
+time: "8:30PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2016-12-05",
+time: "9:00PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2016-12-05",
+time: "10:30PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2016-12-06",
+time: "3:30PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2016-12-06",
+time: "6:00PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2016-12-06",
+time: "6:00PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2016-12-06",
+time: "6:00PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2016-12-06",
+time: "7:00PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2016-12-07",
+time: "7:00PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2016-12-07",
+time: "7:00PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2016-12-07",
+time: "7:30PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2016-12-07",
+time: "7:30PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2016-12-07",
+time: "7:30PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2016-12-07",
+time: "8:00PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2016-12-07",
+time: "8:00PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2016-12-07",
+time: "8:00PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2016-12-07",
+time: "8:00PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2016-12-08",
+time: "7:00PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2016-12-08",
+time: "7:00PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2016-12-08",
+time: "7:30PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2016-12-08",
+time: "8:00PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2016-12-08",
+time: "9:00PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2016-12-08",
+time: "10:00PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2016-12-09",
+time: "7:00PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2016-12-09",
+time: "7:00PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2016-12-09",
+time: "7:00PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2016-12-09",
+time: "7:30PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2016-12-09",
+time: "7:30PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2016-12-09",
+time: "8:00PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2016-12-09",
+time: "8:00PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2016-12-09",
+time: "9:00PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2016-12-09",
+time: "9:00PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2016-12-09",
+time: "9:30PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2016-12-10",
+time: "7:30PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2016-12-10",
+time: "8:00PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2016-12-10",
+time: "8:00PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2016-12-10",
+time: "10:30PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2016-12-11",
+time: "7:00PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2016-12-11",
+time: "7:00PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2016-12-11",
+time: "7:00PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2016-12-11",
+time: "7:30PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2016-12-11",
+time: "7:30PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2016-12-11",
+time: "8:00PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2016-12-11",
+time: "8:00PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2016-12-11",
+time: "9:00PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2016-12-11",
+time: "9:00PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2016-12-11",
+time: "9:30PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2016-12-11",
+time: "9:30PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2016-12-12",
+time: "5:00PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2016-12-12",
+time: "7:00PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2016-12-12",
+time: "7:30PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2016-12-12",
+time: "8:00PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2016-12-12",
+time: "8:00PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2016-12-12",
+time: "8:00PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2016-12-12",
+time: "8:30PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2016-12-12",
+time: "8:30PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2016-12-12",
+time: "10:00PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2016-12-13",
+time: "3:30PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2016-12-13",
+time: "6:00PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2016-12-13",
+time: "6:00PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2016-12-13",
+time: "7:00PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2016-12-14",
+time: "7:00PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2016-12-14",
+time: "7:30PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2016-12-14",
+time: "7:30PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2016-12-14",
+time: "8:00PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2016-12-14",
+time: "8:00PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2016-12-14",
+time: "8:00PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2016-12-14",
+time: "8:30PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2016-12-14",
+time: "8:30PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2016-12-14",
+time: "9:00PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2016-12-14",
+time: "10:00PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2016-12-15",
+time: "7:30PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2016-12-15",
+time: "8:00PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2016-12-15",
+time: "10:00PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2016-12-15",
+time: "10:30PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2016-12-16",
+time: "7:00PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2016-12-16",
+time: "7:00PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2016-12-16",
+time: "7:30PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2016-12-16",
+time: "7:30PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2016-12-16",
+time: "7:30PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2016-12-16",
+time: "8:00PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2016-12-16",
+time: "8:00PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2016-12-16",
+time: "8:00PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2016-12-16",
+time: "8:30PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2016-12-16",
+time: "9:00PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2016-12-16",
+time: "10:30PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2016-12-16",
+time: "10:30PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2016-12-17",
+time: "7:00PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2016-12-17",
+time: "8:00PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2016-12-17",
+time: "10:30PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2016-12-18",
+time: "7:00PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2016-12-18",
+time: "7:00PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2016-12-18",
+time: "7:00PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2016-12-18",
+time: "7:30PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2016-12-18",
+time: "8:00PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2016-12-18",
+time: "8:00PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2016-12-18",
+time: "8:00PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2016-12-18",
+time: "8:00PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2016-12-18",
+time: "8:30PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2016-12-18",
+time: "9:00PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2016-12-18",
+time: "10:30PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2016-12-18",
+time: "10:30PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2016-12-19",
+time: "5:00PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2016-12-19",
+time: "7:00PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2016-12-19",
+time: "7:30PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2016-12-19",
+time: "8:00PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2016-12-19",
+time: "8:00PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2016-12-20",
+time: "1:00PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2016-12-20",
+time: "1:00PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2016-12-20",
+time: "3:30PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2016-12-20",
+time: "5:00PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2016-12-20",
+time: "6:00PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2016-12-20",
+time: "6:00PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2016-12-20",
+time: "8:00PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2016-12-21",
+time: "7:00PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2016-12-21",
+time: "7:30PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2016-12-21",
+time: "7:30PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2016-12-21",
+time: "8:00PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2016-12-21",
+time: "8:00PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2016-12-21",
+time: "8:00PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2016-12-21",
+time: "8:30PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2016-12-21",
+time: "9:00PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2016-12-21",
+time: "10:30PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2016-12-22",
+time: "7:00PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2016-12-22",
+time: "7:30PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2016-12-22",
+time: "7:30PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2016-12-22",
+time: "9:00PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2016-12-23",
+time: "7:00PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2016-12-23",
+time: "7:00PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2016-12-23",
+time: "7:00PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2016-12-23",
+time: "7:00PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2016-12-23",
+time: "7:00PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2016-12-23",
+time: "7:30PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2016-12-23",
+time: "8:00PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2016-12-23",
+time: "8:00PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2016-12-23",
+time: "8:00PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2016-12-23",
+time: "8:00PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2016-12-23",
+time: "9:00PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2016-12-23",
+time: "10:30PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2016-12-23",
+time: "10:30PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2016-12-25",
+time: "2:30PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2016-12-25",
+time: "2:30PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2016-12-25",
+time: "5:00PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2016-12-25",
+time: "8:00PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2016-12-25",
+time: "10:30PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2016-12-26",
+time: "4:00PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2016-12-26",
+time: "5:00PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2016-12-26",
+time: "7:00PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2016-12-26",
+time: "7:00PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2016-12-26",
+time: "7:00PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2016-12-26",
+time: "7:30PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2016-12-26",
+time: "7:30PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2016-12-26",
+time: "8:00PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2016-12-26",
+time: "8:30PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2016-12-26",
+time: "8:30PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2016-12-26",
+time: "9:00PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2016-12-26",
+time: "9:00PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2016-12-26",
+time: "10:00PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2016-12-27",
+time: "6:00PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2016-12-27",
+time: "7:00PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2016-12-27",
+time: "7:00PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2016-12-27",
+time: "9:00PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2016-12-28",
+time: "7:00PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2016-12-28",
+time: "7:00PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2016-12-28",
+time: "7:00PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2016-12-28",
+time: "7:00PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2016-12-28",
+time: "7:30PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2016-12-28",
+time: "8:00PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2016-12-28",
+time: "8:30PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2016-12-28",
+time: "8:30PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2016-12-28",
+time: "9:00PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2016-12-28",
+time: "9:00PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2016-12-28",
+time: "10:30PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2016-12-29",
+time: "7:00PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2016-12-29",
+time: "7:30PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2016-12-29",
+time: "8:00PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2016-12-29",
+time: "8:00PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2016-12-29",
+time: "9:00PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2016-12-30",
+time: "7:00PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2016-12-30",
+time: "7:00PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2016-12-30",
+time: "7:30PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2016-12-30",
+time: "7:30PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2016-12-30",
+time: "8:00PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2016-12-30",
+time: "8:00PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2016-12-30",
+time: "8:30PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2016-12-30",
+time: "8:30PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2016-12-30",
+time: "10:00PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2016-12-30",
+time: "10:00PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2016-12-31",
+time: "6:00PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2016-12-31",
+time: "6:00PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2016-12-31",
+time: "7:00PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2016-12-31",
+time: "8:00PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2016-12-31",
+time: "8:00PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2016-12-31",
+time: "9:00PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2017-01-01",
+time: "7:00PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2017-01-01",
+time: "7:30PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2017-01-01",
+time: "7:30PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2017-01-01",
+time: "8:00PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2017-01-01",
+time: "10:30PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2017-01-02",
+time: "3:00PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2017-01-02",
+time: "5:00PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2017-01-02",
+time: "7:00PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2017-01-02",
+time: "7:00PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2017-01-02",
+time: "7:30PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2017-01-02",
+time: "8:00PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2017-01-02",
+time: "8:30PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2017-01-02",
+time: "8:30PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2017-01-02",
+time: "9:00PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2017-01-02",
+time: "10:30PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2017-01-02",
+time: "10:30PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2017-01-03",
+time: "3:30PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2017-01-03",
+time: "3:30PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2017-01-03",
+time: "6:00PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2017-01-03",
+time: "9:00PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2017-01-03",
+time: "9:30PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2017-01-04",
+time: "7:00PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2017-01-04",
+time: "7:00PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2017-01-04",
+time: "7:30PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2017-01-04",
+time: "7:30PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2017-01-04",
+time: "7:30PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2017-01-04",
+time: "8:00PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2017-01-04",
+time: "8:00PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2017-01-04",
+time: "9:00PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2017-01-04",
+time: "10:00PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2017-01-04",
+time: "10:30PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2017-01-05",
+time: "8:00PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2017-01-05",
+time: "8:00PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2017-01-05",
+time: "8:30PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2017-01-05",
+time: "10:30PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2017-01-06",
+time: "7:00PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2017-01-06",
+time: "7:00PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2017-01-06",
+time: "7:00PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2017-01-06",
+time: "7:30PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2017-01-06",
+time: "7:30PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2017-01-06",
+time: "8:00PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2017-01-06",
+time: "8:00PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2017-01-06",
+time: "8:30PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2017-01-06",
+time: "9:00PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2017-01-06",
+time: "9:30PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2017-01-06",
+time: "10:00PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2017-01-07",
+time: "7:00PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2017-01-07",
+time: "8:00PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2017-01-07",
+time: "8:00PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2017-01-07",
+time: "10:30PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2017-01-08",
+time: "7:00PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2017-01-08",
+time: "7:30PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2017-01-08",
+time: "8:00PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2017-01-08",
+time: "8:00PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2017-01-08",
+time: "8:00PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2017-01-08",
+time: "8:00PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2017-01-08",
+time: "8:30PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2017-01-08",
+time: "9:30PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2017-01-08",
+time: "10:00PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2017-01-08",
+time: "10:30PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2017-01-09",
+time: "3:30PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2017-01-09",
+time: "5:00PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2017-01-09",
+time: "7:00PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2017-01-09",
+time: "7:30PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2017-01-09",
+time: "7:30PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2017-01-09",
+time: "9:00PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2017-01-09",
+time: "10:00PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2017-01-10",
+time: "3:30PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2017-01-10",
+time: "5:00PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2017-01-10",
+time: "6:00PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2017-01-10",
+time: "6:00PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2017-01-10",
+time: "7:00PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2017-01-10",
+time: "7:30PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2017-01-10",
+time: "8:00PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2017-01-10",
+time: "9:00PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2017-01-10",
+time: "9:30PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2017-01-11",
+time: "7:30PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2017-01-11",
+time: "8:00PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2017-01-11",
+time: "10:30PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2017-01-12",
+time: "7:00PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2017-01-12",
+time: "7:30PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2017-01-12",
+time: "7:30PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2017-01-12",
+time: "8:00PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2017-01-12",
+time: "8:00PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2017-01-12",
+time: "8:00PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2017-01-12",
+time: "8:30PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2017-01-12",
+time: "10:30PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2017-01-13",
+time: "7:00PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2017-01-13",
+time: "7:00PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2017-01-13",
+time: "7:30PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2017-01-13",
+time: "8:00PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2017-01-13",
+time: "8:00PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2017-01-13",
+time: "8:00PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2017-01-13",
+time: "9:00PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2017-01-13",
+time: "10:00PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2017-01-13",
+time: "10:00PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2017-01-13",
+time: "10:30PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2017-01-14",
+time: "3:00PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2017-01-14",
+time: "7:00PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2017-01-14",
+time: "8:00PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2017-01-14",
+time: "8:00PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2017-01-14",
+time: "9:00PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2017-01-14",
+time: "10:30PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2017-01-15",
+time: "7:00PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2017-01-15",
+time: "7:00PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2017-01-15",
+time: "7:30PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2017-01-15",
+time: "7:30PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2017-01-15",
+time: "8:00PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2017-01-15",
+time: "8:00PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2017-01-15",
+time: "8:00PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2017-01-15",
+time: "9:00PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2017-01-15",
+time: "9:30PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2017-01-16",
+time: "7:00PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2017-01-16",
+time: "7:30PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2017-01-16",
+time: "7:30PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2017-01-16",
+time: "7:30PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2017-01-16",
+time: "7:30PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2017-01-16",
+time: "8:00PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2017-01-16",
+time: "9:00PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2017-01-16",
+time: "10:30PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2017-01-17",
+time: "3:30PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2017-01-17",
+time: "7:00PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2017-01-17",
+time: "7:00PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2017-01-17",
+time: "8:00PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2017-01-17",
+time: "9:30PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2017-01-18",
+time: "1:00PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2017-01-18",
+time: "2:00PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2017-01-18",
+time: "2:00PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2017-01-18",
+time: "2:30PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2017-01-18",
+time: "3:30PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2017-01-18",
+time: "5:00PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2017-01-18",
+time: "7:30PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2017-01-18",
+time: "8:00PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2017-01-18",
+time: "8:30PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2017-01-18",
+time: "10:30PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2017-01-19",
+time: "7:30PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2017-01-19",
+time: "8:00PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2017-01-19",
+time: "9:00PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2017-01-19",
+time: "9:00PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2017-01-20",
+time: "7:00PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2017-01-20",
+time: "7:00PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2017-01-20",
+time: "7:30PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2017-01-20",
+time: "7:30PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2017-01-20",
+time: "7:30PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2017-01-20",
+time: "8:00PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2017-01-20",
+time: "8:00PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2017-01-20",
+time: "8:00PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2017-01-20",
+time: "8:30PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2017-01-20",
+time: "10:30PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2017-01-20",
+time: "10:30PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2017-01-21",
+time: "8:00PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2017-01-21",
+time: "8:00PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2017-01-21",
+time: "9:00PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2017-01-21",
+time: "10:00PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2017-01-21",
+time: "10:30PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2017-01-22",
+time: "7:00PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2017-01-22",
+time: "7:30PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2017-01-22",
+time: "7:30PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2017-01-22",
+time: "7:30PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2017-01-22",
+time: "8:00PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2017-01-22",
+time: "8:00PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2017-01-22",
+time: "8:30PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2017-01-22",
+time: "10:30PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2017-01-22",
+time: "10:30PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2017-01-23",
+time: "7:00PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2017-01-23",
+time: "7:00PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2017-01-23",
+time: "8:00PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2017-01-23",
+time: "8:30PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2017-01-23",
+time: "9:00PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2017-01-23",
+time: "9:30PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2017-01-23",
+time: "10:30PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2017-01-23",
+time: "10:30PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2017-01-24",
+time: "3:30PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2017-01-24",
+time: "6:00PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2017-01-24",
+time: "7:00PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2017-01-24",
+time: "7:30PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2017-01-25",
+time: "7:00PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2017-01-25",
+time: "7:00PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2017-01-25",
+time: "8:00PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2017-01-25",
+time: "8:00PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2017-01-25",
+time: "8:00PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2017-01-25",
+time: "9:00PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2017-01-25",
+time: "9:00PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2017-01-25",
+time: "10:00PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2017-01-25",
+time: "10:30PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2017-01-26",
+time: "7:00PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2017-01-26",
+time: "7:00PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2017-01-26",
+time: "7:30PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2017-01-26",
+time: "7:30PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2017-01-26",
+time: "7:30PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2017-01-26",
+time: "8:00PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2017-01-26",
+time: "10:00PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2017-01-26",
+time: "10:30PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2017-01-27",
+time: "7:00PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2017-01-27",
+time: "7:30PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2017-01-27",
+time: "7:30PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2017-01-27",
+time: "8:00PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2017-01-27",
+time: "8:00PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2017-01-27",
+time: "8:00PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2017-01-27",
+time: "9:00PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2017-01-27",
+time: "10:30PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2017-01-28",
+time: "7:00PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2017-01-28",
+time: "7:00PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2017-01-28",
+time: "8:00PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2017-01-28",
+time: "8:00PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2017-01-28",
+time: "8:00PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2017-01-28",
+time: "10:30PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2017-01-29",
+time: "7:30PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2017-01-29",
+time: "7:30PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2017-01-29",
+time: "7:30PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2017-01-29",
+time: "8:00PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2017-01-29",
+time: "8:00PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2017-01-29",
+time: "8:30PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2017-01-29",
+time: "9:00PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2017-01-29",
+time: "10:00PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2017-01-29",
+time: "10:30PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2017-01-30",
+time: "5:00PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2017-01-30",
+time: "6:30PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2017-01-30",
+time: "7:00PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2017-01-30",
+time: "7:00PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2017-01-30",
+time: "8:00PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2017-01-30",
+time: "8:00PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2017-01-30",
+time: "8:30PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2017-01-31",
+time: "3:30PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2017-01-31",
+time: "6:00PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2017-01-31",
+time: "6:00PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2017-01-31",
+time: "7:00PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2017-01-31",
+time: "7:30PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2017-01-31",
+time: "9:00PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2017-01-31",
+time: "9:30PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2017-02-01",
+time: "7:00PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2017-02-01",
+time: "7:30PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2017-02-01",
+time: "8:00PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2017-02-01",
+time: "8:00PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2017-02-01",
+time: "8:00PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2017-02-01",
+time: "8:30PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2017-02-01",
+time: "9:00PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2017-02-01",
+time: "9:00PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2017-02-01",
+time: "10:00PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2017-02-02",
+time: "7:30PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2017-02-02",
+time: "8:00PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2017-02-02",
+time: "9:00PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2017-02-02",
+time: "10:00PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2017-02-02",
+time: "10:30PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2017-02-03",
+time: "7:00PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2017-02-03",
+time: "7:00PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2017-02-03",
+time: "7:30PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2017-02-03",
+time: "7:30PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2017-02-03",
+time: "8:00PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2017-02-03",
+time: "8:00PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2017-02-03",
+time: "8:30PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2017-02-03",
+time: "8:30PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2017-02-03",
+time: "9:00PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2017-02-03",
+time: "10:00PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2017-02-03",
+time: "10:30PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2017-02-04",
+time: "7:00PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2017-02-04",
+time: "9:00PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2017-02-04",
+time: "9:30PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2017-02-04",
+time: "10:00PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2017-02-05",
+time: "7:00PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2017-02-05",
+time: "7:00PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2017-02-05",
+time: "7:00PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2017-02-05",
+time: "7:00PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2017-02-05",
+time: "7:30PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2017-02-05",
+time: "7:30PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2017-02-05",
+time: "7:30PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2017-02-05",
+time: "9:00PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2017-02-05",
+time: "9:00PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2017-02-05",
+time: "9:30PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2017-02-06",
+time: "5:00PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2017-02-06",
+time: "7:00PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2017-02-06",
+time: "7:00PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2017-02-06",
+time: "7:30PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2017-02-06",
+time: "7:30PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2017-02-06",
+time: "8:00PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2017-02-06",
+time: "8:00PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2017-02-06",
+time: "8:30PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2017-02-06",
+time: "9:00PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2017-02-06",
+time: "9:00PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2017-02-07",
+time: "1:00PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2017-02-07",
+time: "1:00PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2017-02-07",
+time: "1:00PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2017-02-07",
+time: "2:00PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2017-02-08",
+time: "7:00PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2017-02-08",
+time: "7:00PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2017-02-08",
+time: "7:00PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2017-02-08",
+time: "7:00PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2017-02-08",
+time: "7:30PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2017-02-08",
+time: "7:30PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2017-02-08",
+time: "8:00PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2017-02-08",
+time: "8:00PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2017-02-08",
+time: "8:00PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2017-02-08",
+time: "9:00PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2017-02-09",
+time: "8:00PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2017-02-09",
+time: "8:00PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2017-02-09",
+time: "8:00PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2017-02-09",
+time: "8:30PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2017-02-09",
+time: "10:30PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2017-02-10",
+time: "7:00PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2017-02-10",
+time: "7:00PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2017-02-10",
+time: "7:00PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2017-02-10",
+time: "7:30PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2017-02-10",
+time: "7:30PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2017-02-10",
+time: "7:30PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2017-02-10",
+time: "8:00PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2017-02-10",
+time: "8:00PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2017-02-10",
+time: "8:00PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2017-02-10",
+time: "8:00PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2017-02-10",
+time: "9:00PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2017-02-10",
+time: "10:30PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2017-02-11",
+time: "8:00PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2017-02-11",
+time: "8:00PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2017-02-18",
+time: "7:00PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2017-02-18",
+time: "8:00PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2017-02-18",
+time: "10:30PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2017-02-19",
+time: "7:00PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2017-02-19",
+time: "7:00PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2017-02-19",
+time: "7:30PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2017-02-19",
+time: "8:00PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2017-02-19",
+time: "8:00PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2017-02-19",
+time: "8:00PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2017-02-19",
+time: "8:00PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2017-02-19",
+time: "8:00PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2017-02-19",
+time: "8:00PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2017-02-19",
+time: "9:30PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2017-02-19",
+time: "10:00PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2017-02-19",
+time: "10:00PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2017-02-19",
+time: "10:30PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2017-02-19",
+time: "10:30PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2017-02-20",
+time: "7:30PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2017-02-20",
+time: "7:30PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2017-02-20",
+time: "8:00PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2017-02-20",
+time: "8:30PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2017-02-21",
+time: "3:30PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2017-02-21",
+time: "3:30PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2017-02-21",
+time: "5:00PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2017-02-21",
+time: "5:00PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2017-02-21",
+time: "6:00PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2017-02-21",
+time: "6:00PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2017-02-21",
+time: "6:00PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2017-02-21",
+time: "7:00PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2017-02-21",
+time: "8:00PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2017-02-21",
+time: "9:00PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2017-02-22",
+time: "7:00PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2017-02-22",
+time: "7:30PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2017-02-22",
+time: "7:30PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2017-02-22",
+time: "8:00PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2017-02-22",
+time: "8:00PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2017-02-22",
+time: "8:00PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2017-02-22",
+time: "10:30PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2017-02-23",
+time: "7:00PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2017-02-23",
+time: "7:00PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2017-02-23",
+time: "9:00PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2017-02-23",
+time: "9:00PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2017-02-23",
+time: "10:00PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2017-02-24",
+time: "7:00PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2017-02-24",
+time: "7:00PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2017-02-24",
+time: "7:30PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2017-02-24",
+time: "7:30PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2017-02-24",
+time: "7:30PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2017-02-24",
+time: "8:00PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2017-02-24",
+time: "8:00PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2017-02-24",
+time: "8:30PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2017-02-24",
+time: "10:30PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2017-02-24",
+time: "10:30PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2017-02-25",
+time: "7:00PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2017-02-25",
+time: "7:30PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2017-02-25",
+time: "8:00PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2017-02-25",
+time: "9:00PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2017-02-25",
+time: "10:30PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2017-02-25",
+time: "10:30PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2017-02-26",
+time: "7:00PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2017-02-26",
+time: "7:00PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2017-02-26",
+time: "7:30PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2017-02-26",
+time: "7:30PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2017-02-26",
+time: "8:00PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2017-02-26",
+time: "8:30PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2017-02-26",
+time: "10:00PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2017-02-26",
+time: "10:30PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2017-02-27",
+time: "3:00PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2017-02-27",
+time: "7:00PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2017-02-27",
+time: "8:00PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2017-02-27",
+time: "8:00PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2017-02-27",
+time: "8:30PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2017-02-27",
+time: "8:30PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2017-02-27",
+time: "9:30PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2017-02-27",
+time: "9:30PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2017-02-28",
+time: "1:00PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2017-02-28",
+time: "3:30PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2017-02-28",
+time: "6:00PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2017-02-28",
+time: "6:00PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2017-02-28",
+time: "6:00PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2017-02-28",
+time: "7:00PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2017-02-28",
+time: "7:30PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2017-02-29",
+time: "7:00PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2017-02-29",
+time: "7:00PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2017-02-29",
+time: "7:30PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2017-02-29",
+time: "8:00PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2017-02-29",
+time: "9:00PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2017-02-29",
+time: "10:00PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2017-02-29",
+time: "10:30PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2017-03-01",
+time: "7:00PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2017-03-01",
+time: "7:30PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2017-03-01",
+time: "7:30PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2017-03-01",
+time: "8:30PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2017-03-01",
+time: "10:30PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2017-03-01",
+time: "10:30PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2017-03-02",
+time: "7:00PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2017-03-02",
+time: "7:00PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2017-03-02",
+time: "7:30PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2017-03-02",
+time: "7:30PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2017-03-02",
+time: "8:00PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2017-03-02",
+time: "8:00PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2017-03-02",
+time: "8:00PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2017-03-02",
+time: "8:00PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2017-03-02",
+time: "8:00PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2017-03-02",
+time: "9:00PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2017-03-02",
+time: "10:30PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2017-03-03",
+time: "7:30PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2017-03-03",
+time: "8:00PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2017-03-03",
+time: "8:30PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2017-03-03",
+time: "10:30PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2017-03-04",
+time: "7:00PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2017-03-04",
+time: "7:00PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2017-03-04",
+time: "7:00PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2017-03-04",
+time: "7:30PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2017-03-04",
+time: "7:30PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2017-03-04",
+time: "8:00PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2017-03-04",
+time: "8:00PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2017-03-04",
+time: "8:00PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2017-03-04",
+time: "9:00PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2017-03-04",
+time: "10:30PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2017-03-05",
+time: "7:00PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2017-03-05",
+time: "7:00PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2017-03-05",
+time: "7:00PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2017-03-05",
+time: "7:00PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2017-03-05",
+time: "8:00PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2017-03-05",
+time: "8:30PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2017-03-05",
+time: "8:30PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2017-03-05",
+time: "10:30PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2017-03-06",
+time: "3:30PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2017-03-06",
+time: "3:30PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2017-03-06",
+time: "4:00PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2017-03-06",
+time: "5:00PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2017-03-06",
+time: "6:00PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2017-03-06",
+time: "6:00PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2017-03-06",
+time: "6:30PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2017-03-07",
+time: "7:00PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2017-03-07",
+time: "7:00PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2017-03-07",
+time: "7:00PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2017-03-07",
+time: "8:00PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2017-03-07",
+time: "8:00PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2017-03-07",
+time: "8:30PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2017-03-07",
+time: "10:30PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2017-03-08",
+time: "7:30PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2017-03-08",
+time: "8:00PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2017-03-08",
+time: "9:00PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2017-03-08",
+time: "9:00PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2017-03-08",
+time: "10:00PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2017-03-08",
+time: "10:30PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2017-03-09",
+time: "7:00PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2017-03-09",
+time: "7:00PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2017-03-09",
+time: "7:00PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2017-03-09",
+time: "8:00PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2017-03-09",
+time: "8:30PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2017-03-09",
+time: "9:00PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2017-03-09",
+time: "9:30PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2017-03-09",
+time: "10:00PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2017-03-09",
+time: "10:30PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2017-03-10",
+time: "7:30PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2017-03-10",
+time: "8:00PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2017-03-10",
+time: "9:00PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2017-03-10",
+time: "10:30PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2017-03-11",
+time: "7:00PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2017-03-11",
+time: "7:00PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2017-03-11",
+time: "7:30PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2017-03-11",
+time: "8:00PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2017-03-11",
+time: "8:00PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2017-03-11",
+time: "8:00PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2017-03-11",
+time: "9:00PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2017-03-11",
+time: "10:00PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2017-03-11",
+time: "10:30PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2017-03-11",
+time: "10:30PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2017-03-12",
+time: "2:00PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2017-03-12",
+time: "7:00PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2017-03-12",
+time: "7:00PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2017-03-12",
+time: "7:00PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2017-03-12",
+time: "7:30PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2017-03-12",
+time: "7:30PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2017-03-12",
+time: "8:30PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2017-03-12",
+time: "9:30PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2017-03-12",
+time: "10:30PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2017-03-12",
+time: "10:30PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2017-03-13",
+time: "3:30PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2017-03-13",
+time: "6:00PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2017-03-13",
+time: "6:00PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2017-03-13",
+time: "8:00PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2017-03-13",
+time: "9:30PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2017-03-14",
+time: "7:00PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2017-03-14",
+time: "7:30PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2017-03-14",
+time: "7:30PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2017-03-14",
+time: "8:00PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2017-03-14",
+time: "8:00PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2017-03-14",
+time: "8:00PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2017-03-14",
+time: "10:00PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2017-03-14",
+time: "10:30PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2017-03-14",
+time: "10:30PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2017-03-15",
+time: "7:00PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2017-03-15",
+time: "7:00PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2017-03-15",
+time: "7:30PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2017-03-15",
+time: "8:00PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2017-03-15",
+time: "8:30PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2017-03-15",
+time: "10:30PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2017-03-16",
+time: "7:00PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2017-03-16",
+time: "7:00PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2017-03-16",
+time: "7:00PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2017-03-16",
+time: "7:00PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2017-03-16",
+time: "7:30PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2017-03-16",
+time: "8:00PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2017-03-16",
+time: "9:30PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2017-03-16",
+time: "10:00PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2017-03-16",
+time: "10:30PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2017-03-17",
+time: "7:00PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2017-03-17",
+time: "7:00PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2017-03-17",
+time: "7:30PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2017-03-17",
+time: "8:00PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2017-03-17",
+time: "8:00PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2017-03-17",
+time: "8:00PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2017-03-17",
+time: "8:30PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2017-03-17",
+time: "9:00PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2017-03-18",
+time: "7:00PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2017-03-18",
+time: "7:00PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2017-03-18",
+time: "7:30PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2017-03-18",
+time: "7:30PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2017-03-18",
+time: "8:00PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2017-03-18",
+time: "8:00PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2017-03-18",
+time: "8:30PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2017-03-18",
+time: "10:30PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2017-03-19",
+time: "6:00PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2017-03-19",
+time: "7:00PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2017-03-19",
+time: "7:00PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2017-03-19",
+time: "7:00PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2017-03-19",
+time: "7:30PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2017-03-19",
+time: "7:30PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2017-03-19",
+time: "8:00PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2017-03-19",
+time: "8:00PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2017-03-19",
+time: "8:30PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2017-03-20",
+time: "4:00PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2017-03-20",
+time: "4:30PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2017-03-20",
+time: "6:00PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2017-03-20",
+time: "6:00PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2017-03-20",
+time: "7:00PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2017-03-20",
+time: "7:30PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2017-03-21",
+time: "7:00PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2017-03-21",
+time: "7:00PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2017-03-21",
+time: "7:00PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2017-03-21",
+time: "7:30PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2017-03-21",
+time: "7:30PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2017-03-21",
+time: "8:00PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2017-03-21",
+time: "8:00PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2017-03-21",
+time: "8:00PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2017-03-21",
+time: "10:00PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2017-03-22",
+time: "7:30PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2017-03-22",
+time: "8:00PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2017-03-22",
+time: "8:00PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2017-03-22",
+time: "10:30PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2017-03-23",
+time: "7:00PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2017-03-23",
+time: "7:00PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2017-03-23",
+time: "7:30PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2017-03-23",
+time: "7:30PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2017-03-23",
+time: "8:00PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2017-03-23",
+time: "8:00PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2017-03-23",
+time: "8:00PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2017-03-23",
+time: "8:30PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2017-03-23",
+time: "9:00PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2017-03-23",
+time: "10:00PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2017-03-23",
+time: "10:00PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2017-03-23",
+time: "10:30PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2017-03-24",
+time: "7:00PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2017-03-24",
+time: "7:30PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2017-03-24",
+time: "7:30PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2017-03-24",
+time: "8:00PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2017-03-24",
+time: "10:30PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2017-03-25",
+time: "7:00PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2017-03-25",
+time: "7:30PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2017-03-25",
+time: "8:00PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2017-03-25",
+time: "8:00PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2017-03-25",
+time: "8:00PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2017-03-25",
+time: "8:30PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2017-03-25",
+time: "10:00PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2017-03-25",
+time: "10:30PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2017-03-25",
+time: "10:30PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2017-03-26",
+time: "6:00PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2017-03-26",
+time: "7:00PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2017-03-26",
+time: "7:00PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2017-03-26",
+time: "7:30PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2017-03-26",
+time: "7:30PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2017-03-26",
+time: "8:00PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2017-03-26",
+time: "8:00PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2017-03-26",
+time: "8:30PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2017-03-26",
+time: "10:00PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2017-03-26",
+time: "10:00PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2017-03-27",
+time: "3:30PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2017-03-27",
+time: "6:00PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2017-03-27",
+time: "6:00PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2017-03-27",
+time: "8:00PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2017-03-27",
+time: "9:30PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2017-03-28",
+time: "7:30PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2017-03-28",
+time: "7:30PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2017-03-28",
+time: "8:00PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2017-03-28",
+time: "8:00PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2017-03-28",
+time: "8:00PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2017-03-28",
+time: "8:00PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2017-03-28",
+time: "9:00PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2017-03-28",
+time: "9:00PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2017-03-28",
+time: "10:00PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2017-03-28",
+time: "10:30PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2017-03-29",
+time: "7:00PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2017-03-29",
+time: "7:00PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2017-03-29",
+time: "7:00PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2017-03-29",
+time: "7:30PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2017-03-29",
+time: "8:00PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2017-03-29",
+time: "10:30PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2017-03-30",
+time: "7:30PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2017-03-30",
+time: "8:00PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2017-03-30",
+time: "8:00PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2017-03-30",
+time: "8:00PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2017-03-30",
+time: "8:30PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2017-03-30",
+time: "8:30PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2017-03-30",
+time: "9:00PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2017-03-30",
+time: "10:00PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2017-03-30",
+time: "10:30PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2017-03-31",
+time: "7:00PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2017-03-31",
+time: "7:00PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2017-03-31",
+time: "7:00PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2017-03-31",
+time: "8:00PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2017-03-31",
+time: "9:30PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2017-03-31",
+time: "10:00PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2017-04-01",
+time: "7:00PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2017-04-01",
+time: "7:30PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2017-04-01",
+time: "7:30PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2017-04-01",
+time: "8:00PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2017-04-01",
+time: "8:00PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2017-04-01",
+time: "8:00PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2017-04-01",
+time: "9:00PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2017-04-01",
+time: "10:00PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2017-04-01",
+time: "10:30PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2017-04-01",
+time: "10:30PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2017-04-02",
+time: "7:30PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2017-04-02",
+time: "8:00PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2017-04-02",
+time: "8:30PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2017-04-02",
+time: "9:00PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2017-04-02",
+time: "10:00PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2017-04-03",
+time: "1:00PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2017-04-03",
+time: "3:30PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2017-04-03",
+time: "3:30PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2017-04-03",
+time: "3:30PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2017-04-03",
+time: "3:30PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2017-04-03",
+time: "6:00PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2017-04-03",
+time: "6:00PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2017-04-03",
+time: "7:00PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2017-04-03",
+time: "7:30PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2017-04-03",
+time: "8:00PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2017-04-03",
+time: "9:30PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2017-04-05",
+time: "7:00PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2017-04-05",
+time: "7:30PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2017-04-05",
+time: "8:00PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2017-04-05",
+time: "8:00PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2017-04-05",
+time: "8:00PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2017-04-05",
+time: "8:00PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2017-04-05",
+time: "9:00PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2017-04-05",
+time: "9:00PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2017-04-05",
+time: "10:00PM",
+awayTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2017-04-05",
+time: "10:30PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2017-04-05",
+time: "10:30PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2017-04-06",
+time: "7:00PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2017-04-06",
+time: "7:00PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2017-04-06",
+time: "7:00PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2017-04-06",
+time: "7:30PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2017-04-06",
+time: "7:30PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2017-04-06",
+time: "9:30PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2017-04-06",
+time: "10:00PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2017-04-06",
+time: "10:30PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2017-04-07",
+time: "8:00PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2017-04-07",
+time: "8:00PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2017-04-07",
+time: "8:00PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2017-04-07",
+time: "10:00PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2017-04-07",
+time: "10:30PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2017-04-08",
+time: "6:30PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2017-04-08",
+time: "6:30PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2017-04-08",
+time: "7:30PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2017-04-08",
+time: "7:30PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2017-04-08",
+time: "7:30PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2017-04-08",
+time: "7:30PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2017-04-08",
+time: "8:00PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2017-04-08",
+time: "8:30PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2017-04-08",
+time: "9:00PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2017-04-08",
+time: "9:00PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2017-04-09",
+time: "7:00PM",
+awayTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2017-04-09",
+time: "7:30PM",
+awayTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+homeTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+location: "Philips Arena"
+},
+{
+date: "2017-04-09",
+time: "8:00PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+location: "FedEx Forum"
+},
+{
+date: "2017-04-09",
+time: "8:30PM",
+awayTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2017-04-09",
+time: "10:30PM",
+awayTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+},
+{
+date: "2017-04-09",
+time: "10:30PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+location: "Sleep Train Arena"
+},
+{
+date: "2017-04-10",
+time: "2:00PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2017-04-10",
+time: "3:30PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2017-04-10",
+time: "3:30PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2017-04-10",
+time: "5:00PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+location: "Pepsi Center"
+},
+{
+date: "2017-04-10",
+time: "5:00PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+location: "Wells Fargo Center"
+},
+{
+date: "2017-04-10",
+time: "6:00PM",
+awayTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2017-04-10",
+time: "6:00PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+location: "American Airlines Arena"
+},
+{
+date: "2017-04-10",
+time: "7:00PM",
+awayTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2017-04-10",
+time: "7:30PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+location: "Madison Square Garden"
+},
+{
+date: "2017-04-11",
+time: "7:00PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2017-04-11",
+time: "7:00PM",
+awayTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+homeTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+location: "Amway Center"
+},
+{
+date: "2017-04-11",
+time: "7:30PM",
+awayTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2017-04-11",
+time: "7:30PM",
+awayTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2017-04-11",
+time: "8:00PM",
+awayTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2017-04-11",
+time: "8:00PM",
+awayTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+homeTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+location: "Smoothie King Center"
+},
+{
+date: "2017-04-11",
+time: "8:00PM",
+awayTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+homeTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+location: "Chesapeake Energy Arena"
+},
+{
+date: "2017-04-11",
+time: "9:00PM",
+awayTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+homeTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+location: "Vivint Smart Home Arena"
+},
+{
+date: "2017-04-11",
+time: "10:00PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2017-04-12",
+time: "7:00PM",
+awayTeam: {
+ID: "83",
+City: "New York",
+Name: "Knicks",
+Abbreviation: "NYK"
+},
+homeTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+location: "Bankers Life Fieldhouse"
+},
+{
+date: "2017-04-12",
+time: "7:30PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+location: "Palace of Auburn Hills"
+},
+{
+date: "2017-04-12",
+time: "7:30PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+location: "Air Canada Centre"
+},
+{
+date: "2017-04-12",
+time: "8:00PM",
+awayTeam: {
+ID: "96",
+City: "Oklahama City",
+Name: "Thunder",
+Abbreviation: "OKL"
+},
+homeTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+location: "AT&T Center"
+},
+{
+date: "2017-04-12",
+time: "10:30PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+location: "Staples Center"
+},
+{
+date: "2017-04-13",
+time: "8:00PM",
+awayTeam: {
+ID: "92",
+City: "Miami",
+Name: "Heat",
+Abbreviation: "MIA"
+},
+homeTeam: {
+ID: "82",
+City: "Boston",
+Name: "Celtics",
+Abbreviation: "BOS"
+},
+location: "TD Garden"
+},
+{
+date: "2017-04-13",
+time: "8:00PM",
+awayTeam: {
+ID: "81",
+City: "Toronto",
+Name: "Raptors",
+Abbreviation: "TOR"
+},
+homeTeam: {
+ID: "84",
+City: "Brooklyn",
+Name: "Nets",
+Abbreviation: "BRO"
+},
+location: "Barclays Center"
+},
+{
+date: "2017-04-13",
+time: "8:00PM",
+awayTeam: {
+ID: "85",
+City: "Philadelphia",
+Name: "76ers",
+Abbreviation: "PHI"
+},
+homeTeam: {
+ID: "89",
+City: "Chicago",
+Name: "Bulls",
+Abbreviation: "CHI"
+},
+location: "United Center"
+},
+{
+date: "2017-04-13",
+time: "8:00PM",
+awayTeam: {
+ID: "95",
+City: "Orlando",
+Name: "Magic",
+Abbreviation: "ORL"
+},
+homeTeam: {
+ID: "93",
+City: "Charlotte",
+Name: "Hornets",
+Abbreviation: "CHA"
+},
+location: "Time Warner Cable Arena"
+},
+{
+date: "2017-04-13",
+time: "8:00PM",
+awayTeam: {
+ID: "88",
+City: "Detroit",
+Name: "Pistons",
+Abbreviation: "DET"
+},
+homeTeam: {
+ID: "86",
+City: "Cleveland",
+Name: "Cavaliers",
+Abbreviation: "CLE"
+},
+location: "Quicken Loans Arena"
+},
+{
+date: "2017-04-13",
+time: "8:00PM",
+awayTeam: {
+ID: "106",
+City: "San Antonio",
+Name: "Spurs",
+Abbreviation: "SAS"
+},
+homeTeam: {
+ID: "108",
+City: "Dallas",
+Name: "Mavericks",
+Abbreviation: "DAL"
+},
+location: "American Airlines Center"
+},
+{
+date: "2017-04-13",
+time: "8:00PM",
+awayTeam: {
+ID: "103",
+City: "Sacramento",
+Name: "Kings",
+Abbreviation: "SAC"
+},
+homeTeam: {
+ID: "109",
+City: "Houston",
+Name: "Rockets",
+Abbreviation: "HOU"
+},
+location: "Toyota Center"
+},
+{
+date: "2017-04-13",
+time: "8:00PM",
+awayTeam: {
+ID: "87",
+City: "Indiana",
+Name: "Pacers",
+Abbreviation: "IND"
+},
+homeTeam: {
+ID: "90",
+City: "Milwaukee",
+Name: "Bucks",
+Abbreviation: "MIL"
+},
+location: "BMO Harris Bradley Center"
+},
+{
+date: "2017-04-13",
+time: "8:00PM",
+awayTeam: {
+ID: "110",
+City: "New Orleans",
+Name: "Pelicans",
+Abbreviation: "NOP"
+},
+homeTeam: {
+ID: "100",
+City: "Minnesota",
+Name: "Timberwolves",
+Abbreviation: "MIN"
+},
+location: "Target Center"
+},
+{
+date: "2017-04-13",
+time: "8:00PM",
+awayTeam: {
+ID: "91",
+City: "Atlanta",
+Name: "Hawks",
+Abbreviation: "ATL"
+},
+homeTeam: {
+ID: "94",
+City: "Washington",
+Name: "Wizards",
+Abbreviation: "WAS"
+},
+location: "Verizon Center"
+},
+{
+date: "2017-04-13",
+time: "10:30PM",
+awayTeam: {
+ID: "107",
+City: "Memphis",
+Name: "Grizzlies",
+Abbreviation: "MEM"
+},
+homeTeam: {
+ID: "101",
+City: "Golden State",
+Name: "Warriors",
+Abbreviation: "GSW"
+},
+location: "Oracle Arena"
+},
+{
+date: "2017-04-13",
+time: "10:30PM",
+awayTeam: {
+ID: "98",
+City: "Utah",
+Name: "Jazz",
+Abbreviation: "UTA"
+},
+homeTeam: {
+ID: "105",
+City: "Los Angeles",
+Name: "Lakers",
+Abbreviation: "LAL"
+},
+location: "Staples Center"
+},
+{
+date: "2017-04-13",
+time: "10:30PM",
+awayTeam: {
+ID: "102",
+City: "Los Angeles",
+Name: "Clippers",
+Abbreviation: "LAC"
+},
+homeTeam: {
+ID: "104",
+City: "Phoenix",
+Name: "Suns",
+Abbreviation: "PHX"
+},
+location: "Talking Stick Resort Arena"
+},
+{
+date: "2017-04-13",
+time: "10:30PM",
+awayTeam: {
+ID: "99",
+City: "Denver",
+Name: "Nuggets",
+Abbreviation: "DEN"
+},
+homeTeam: {
+ID: "97",
+City: "Portland",
+Name: "Trail Blazers",
+Abbreviation: "POR"
+},
+location: "Moda Center"
+}
+]
+}
+}
+)
+
+module.exports = stats;


### PR DESCRIPTION
🇺🇸

- Added historical data from the 2015-2016 NBA season.
- Display "today's" (from a year ago) games, with home city, away city, tip-off, and location.
- Can submit a wager to firebase with user information and wallet